### PR TITLE
Gemspec: make the activerecord 3 dependency explicit

### DIFF
--- a/partitioned.gemspec
+++ b/partitioned.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'pg'
   s.add_dependency 'bulk_data_methods'
   s.add_dependency 'activerecord-redshift-adapter'
-  s.add_development_dependency 'rails', '>= 3.2.8'
+  s.add_dependency 'activerecord', '~> 3.0'
+  s.add_development_dependency 'rails', '~> 3.2.8'
   s.add_development_dependency 'rspec-rails'
 end


### PR DESCRIPTION
Rails 4 support is eagerly awaited but not here yet, see #44. This makes the compatible activerecord versions explicit.