### PR TITLE
Fix bug with array columns

### DIFF
--- a/lib/monkey_patch_activerecord.rb
+++ b/lib/monkey_patch_activerecord.rb
@@ -128,7 +128,9 @@ module ActiveRecord
       im = arel.create_insert
 
       # ****** BEGIN PARTITIONED PATCH ******
-      actual_arel_table = @klass.dynamic_arel_table(Hash[*values.map{|k,v| [k.name,v]}.flatten]) if @klass.respond_to?(:dynamic_arel_table)
+      if @klass.respond_to?(:dynamic_arel_table)
+        actual_arel_table = @klass.dynamic_arel_table(Hash[*values.inject([]) { |result, (k, v)| result += [k.name, v] }])
+      end
       actual_arel_table = @table unless actual_arel_table
       # Original line:
       # im.into @table
@@ -175,7 +177,7 @@ module ActiveRecord
 
       # ****** BEGIN PARTITIONED PATCH ******
       if @klass.respond_to?(:dynamic_arel_table)
-        using_arel_table = @klass.dynamic_arel_table(Hash[*values.map { |k,v| [k.name,v] }.flatten])
+        using_arel_table = @klass.dynamic_arel_table(Hash[*values.inject([]) { |result, (k, v)| result += [k.name, v] }])
         um = scope.where(using_arel_table[@klass.primary_key].eq(id_was || id)).arel.compile_update(substitutes, @klass.primary_key)
 
         # NOTE(hofer): The um variable got set up using

--- a/spec/support/shared_example_spec_helper_for_integer_key.rb
+++ b/spec/support/shared_example_spec_helper_for_integer_key.rb
@@ -8,7 +8,7 @@ shared_examples_for "check that basic operations with postgres works correctly f
   context "when try to create one record" do
 
     it "record created" do
-      expect { subject.create(:name => 'Phil', :company_id => 3, :integer_field => 2)
+      expect { subject.create(:name => 'Phil', :company_id => 3, :integer_field => 2, :tags => ['IT', 'Finance'])
       }.not_to raise_error
     end
 
@@ -18,7 +18,7 @@ shared_examples_for "check that basic operations with postgres works correctly f
 
     it "record created" do
       expect {
-        instance = subject.new(:name => 'Mike', :company_id => 1, :integer_field => 1)
+        instance = subject.new(:name => 'Mike', :company_id => 1, :integer_field => 1, :tags => ['IT', 'Finance'])
         instance.save!
       }.not_to raise_error
     end
@@ -65,6 +65,12 @@ shared_examples_for "check that basic operations with postgres works correctly f
     it "returns updated employee name" do
       subject.update(1, :name => 'Kevin')
       expect(subject.find(1).name).to eq("Kevin")
+    end
+
+    it "updates array attributes" do
+      subject.update(1, :tags => ['Sales', 'Marketing'])
+      result = subject.find(1)
+      expect(result.tags).to eq ['Sales', 'Marketing']
     end
 
   end # when try to update a record with id = 1

--- a/spec/support/shared_example_spec_helper_for_time_key.rb
+++ b/spec/support/shared_example_spec_helper_for_time_key.rb
@@ -10,7 +10,7 @@ shared_examples_for "check that basic operations with postgres works correctly f
   context "when try to create one record" do
 
     it "record created" do
-      expect { subject.create(:name => 'Phil', :company_id => 3, :created_at => DATE_NOW + 1)
+      expect { subject.create(:name => 'Phil', :company_id => 3, :created_at => DATE_NOW + 1, :tags => ['IT', 'Finance'])
       }.not_to raise_error
     end
 
@@ -20,7 +20,7 @@ shared_examples_for "check that basic operations with postgres works correctly f
 
     it "record created" do
       expect {
-        instance = subject.new(:name => 'Mike', :company_id => 1, :created_at => DATE_NOW + 1)
+        instance = subject.new(:name => 'Mike', :company_id => 1, :created_at => DATE_NOW + 1, :tags => ['IT', 'Finance'])
         instance.save!
       }.not_to raise_error
     end
@@ -79,6 +79,12 @@ shared_examples_for "check that basic operations with postgres works correctly f
       result = subject.find(1)
       expect(result.name).to eq "Kevin"
       expect(result.created_at).to eq original_created_at
+    end
+
+    it "updates array attributes" do
+      subject.update(1, :tags => ['Sales', 'Marketing'])
+      result = subject.find(1)
+      expect(result.tags).to eq ['Sales', 'Marketing']
     end
 
   end # when try to update a record with id = 1

--- a/spec/support/tables_spec_helper.rb
+++ b/spec/support/tables_spec_helper.rb
@@ -29,7 +29,8 @@ module TablesSpecHelper
           name             text not null,
           salary           integer default 3,
           company_id       integer not null,
-          integer_field    integer not null default 1
+          integer_field    integer not null default 1,
+          tags             text[]
       );
 
       create schema employees_partitions;


### PR DESCRIPTION
When `ActiveRecord model` has an array attribute `partitioned` gem can throw "odd number of arguments" exception. The issue is caused of the following lines of code:
```Ruby
actual_arel_table = @klass.dynamic_arel_table(Hash[*values.map{|k,v| [k.name,v]}.flatten]) if @klass.respond_to?(:dynamic_arel_table)
```
and
 
```Ruby
using_arel_table = @klass.dynamic_arel_table(Hash[*values.map { |k,v| [k.name,v] }.flatten])
```
**flatten** method could potentially create an array with odd number of elements if **values** looks like this:

```Ruby
{name: 'Joe Doe', company_id: 1, tags: ['IT', 'Finance']}
```


